### PR TITLE
fixed_discrete_covariance: get diagonal indices faster

### DIFF
--- a/covariance_functions/fixed_discrete_covariance.m
+++ b/covariance_functions/fixed_discrete_covariance.m
@@ -36,8 +36,7 @@ function result = fixed_discrete_covariance(K, ~, train_ind, test_ind, i, ~)
 
   % diagonal training variance
   elseif ((nargin == 4) && strcmp(test_ind, 'diag'))
-    diagonal = diag(K);
-    result = diagonal(train_ind);
+    result = K(sub2ind(size(K), train_ind, train_ind));
 
   % test covariance
   elseif (nargin == 4)


### PR DESCRIPTION
Profiling repeated calls to `group_model.model()` (to get learning curves), _way_ too much time was being spent on `diagonal = diag(K)`. This way doesn't copy the diagonal.
